### PR TITLE
Trigger tests automatically at the start of a PR

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -502,7 +502,14 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
             # "React" to the comment to let the user know we have acknowledged their comment!
             comment.create_reaction(reaction_t)
 
-
+    # trigger the 'default' tests if this is the first time we've seen this PR:
+    if not_seen_yet and not dryRun and test_suites.AUTO_TRIGGER_ON_OPEN:
+        for test in test_requirements:
+            test_statuses[test] = 'pending'
+            test_triggered[test] = True
+            tests_to_trigger.append(test)
+        tests_to_trigger = set(tests_to_trigger)
+    
     # now,
     # - trigger tests if indicated (for this specific SHA.)
     # - set the current status for this commit SHA

--- a/test_suites.py
+++ b/test_suites.py
@@ -51,6 +51,8 @@ regex_mentioned = re.compile(TEST_MENTIONED, re.I | re.M)
 SUPPORTED_TESTS = ['build', 'code checks', 'validation']
 DEFAULT_TESTS = ['build']
 
+# Whether to trigger the tests in DEFAULT_TESTS when a PR is opened
+AUTO_TRIGGER_ON_OPEN = True 
 
 TEST_ALIASES = {
     'build': ['mu2e/buildtest'],


### PR DESCRIPTION
Requires hand-triggering of tests afterwards