### PR TITLE
Allow tests to be re-triggered if they failed

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -503,8 +503,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
             comment.create_reaction(reaction_t)
 
     # trigger the 'default' tests if this is the first time we've seen this PR:
-    # re-trigger a build if the HEAD changed.        
-    if (not_seen_yet or base_branch_HEAD_changed) and not dryRun and test_suites.AUTO_TRIGGER_ON_OPEN:
+    if not_seen_yet and not dryRun and test_suites.AUTO_TRIGGER_ON_OPEN:
         for test in test_requirements:
             test_statuses[test] = 'pending'
             test_triggered[test] = True
@@ -612,7 +611,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
             build_queue_str=get_build_queue_size()
         )
 
-    
+
     # decide if we should issue a comment, and what comment to issue
     if not_seen_yet:
         print ("First time seeing this PR - send the user a salutation!")
@@ -626,17 +625,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
                 tests_triggered_msg=tests_triggered_msg,
                 base_branch=pr.base.ref
             ))
-    elif base_branch_HEAD_changed and not dryRun:
-        issue.create_comment(
-            """:memo: The HEAD of `{base_ref}` has changed to {base_sha}. Tests are now out of date.
 
-{test_triggered_msg}
-""".format(
-                base_ref=pr.base.ref,
-                base_sha=master_commit_sha,
-                test_triggered_msg=tests_triggered_msg
-            )
-        )
     elif len(tests_to_trigger) > 0:
         # tests were triggered, let people know about it
         if not dryRun:
@@ -652,5 +641,11 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
         issue.create_comment(
             JOB_STALL_MESSAGE.format(joblist='')
         )
-
+    if base_branch_HEAD_changed and not dryRun and not len(tests_to_trigger) > 0:
+        issue.create_comment(
+            ":memo: The HEAD of `{base_ref}` has changed to {base_sha}. Tests are now out of date.".format(
+                base_ref=pr.base.ref,
+                base_sha=master_commit_sha
+            )
+        )
     

--- a/process_pr.py
+++ b/process_pr.py
@@ -626,7 +626,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
                 tests_triggered_msg=tests_triggered_msg,
                 base_branch=pr.base.ref
             ))
-    elif base_branch_HEAD_changed and not dryRun and not len(tests_to_trigger) > 0:
+    elif base_branch_HEAD_changed and not dryRun:
         issue.create_comment(
             """:memo: The HEAD of `{base_ref}` has changed to {base_sha}. Tests are now out of date.
 

--- a/process_pr.py
+++ b/process_pr.py
@@ -475,7 +475,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
 
             for test in tests:
                 # check that the test has been triggered on this commit first
-                if test in test_triggered and test_triggered[test]:
+                if test in test_triggered and test_triggered[test] and test in test_statuses and not test_statuses[test] in ['failure', 'error']:
                         print ("The test has already been triggered for this ref. It will not be triggered again.")
                         tests_already_triggered.append(test)
                         reaction_t = '-1'


### PR DESCRIPTION
Another very small refinement:

Address cases where things intermittently fail (e.g. g4test03 MT), thus avoiding the need for an extra commit to be pushed

in response to Mu2e/Offline#263