### PR TITLE
A script to delete gists older than 30 days

### DIFF
--- a/cleanup-old-gists
+++ b/cleanup-old-gists
@@ -24,7 +24,15 @@ r = requests.get('https://api.github.com/gists',
 
 response_json = r.json()
 
+# only delete this many gists per-run of this script
+gist_delete_limit = 5
+
+
+gists_deleted = 0
 for gist in response_json:
+    if gists_deleted > gist_delete_limit:
+        print('gist_delete_limit reached - exit for now.')
+        sys.exit(0)
     if 'id' not in gist:
         print(response_json)
         print ("Couldn't find an id field. Assume the API request failed - exit.")
@@ -40,5 +48,6 @@ for gist in response_json:
         r = requests.delete(f'https://api.github.com/gists/{id}', 
                   headers = headers)
         print (f'Deleted {id}.')
+        gists_deleted += 1
 
 

--- a/cleanup-old-gists
+++ b/cleanup-old-gists
@@ -30,7 +30,6 @@ marked = []
 
 print (response_json)
 for gist in response_json:
-    print (gist)
     time_created = dateutil.parser.isoparse(gist['created_at'])
 
     tz = time_created.tzinfo

--- a/cleanup-old-gists
+++ b/cleanup-old-gists
@@ -4,9 +4,7 @@ Delete uploaded logfiles from Gist that are older than 30 days.
 
 """
 
-from os.path import expanduser, dirname, abspath, join, exists
-from sys import exit
-import re, sys, os
+import sys
 from socket import setdefaulttimeout
 setdefaulttimeout(120)
 

--- a/cleanup-old-gists
+++ b/cleanup-old-gists
@@ -26,23 +26,21 @@ r = requests.get('https://api.github.com/gists',
 
 response_json = r.json()
 
-marked = []
-
-print (response_json)
 for gist in response_json:
+    if 'id' not in gist:
+        print(response_json)
+        print ("Couldn't find an id field. Assume the API request failed - exit.")
+        sys.exit(1)
+    
     time_created = dateutil.parser.isoparse(gist['created_at'])
-
-    tz = time_created.tzinfo
-
     id = gist['id']
-
-    age_days = (datetime.now(tz) - time_created).total_seconds() / 86400.0
+    age_days = (datetime.now(time_created.tzinfo) - time_created).total_seconds() / 86400.0
 
     if age_days > 30:
         print (f"Gist {id} is {age_days} days old - will delete.")
-        marked.append(id)
 
-for id in marked:
-    r = requests.delete(f'https://api.github.com/gists/{id}', 
-              headers = headers)
-    print (f'Deleted {id}.')
+        r = requests.delete(f'https://api.github.com/gists/{id}', 
+                  headers = headers)
+        print (f'Deleted {id}.')
+
+

--- a/cleanup-old-gists
+++ b/cleanup-old-gists
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""
+Delete uploaded logfiles from Gist that are older than 30 days.
+
+"""
+
+from os.path import expanduser, dirname, abspath, join, exists
+from sys import exit
+import re, sys, os
+from socket import setdefaulttimeout
+setdefaulttimeout(120)
+
+import json
+import requests
+from datetime import datetime
+import dateutil.parser
+
+# https://docs.github.com/en/rest/reference/gists
+headers = {'Accept': 'application/vnd.github.v3+json',
+          'Authorization': 'token %s' % os.environ['GITHUBTOKEN']
+}
+
+r = requests.get('https://api.github.com/gists', 
+              headers = headers)
+
+
+response_json = r.json()
+
+marked = []
+
+print (response_json)
+for gist in response_json:
+    print (gist)
+    time_created = dateutil.parser.isoparse(gist['created_at'])
+
+    tz = time_created.tzinfo
+
+    id = gist['id']
+
+    age_days = (datetime.now(tz) - time_created).total_seconds() / 86400.0
+
+    if age_days > 30:
+        print (f"Gist {id} is {age_days} days old - will delete.")
+        marked.append(id)
+
+for id in marked:
+    r = requests.delete(f'https://api.github.com/gists/{id}', 
+              headers = headers)
+    print (f'Deleted {id}.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ PyYAML==5.3.1
 requests==2.24.0
 urllib3==1.25.10
 wrapt==1.12.1
+python-dateutil==2.8.1


### PR DESCRIPTION
Another loose end that I said I'd take care of (but didn't!)

Suggest to add the line

```bash
${CMS_BOT_DIR}/cleanup-old-gists
```
to 
https://github.com/Mu2e/codetools/blob/79530e954cf000857233b24473b1e1ab73216e7b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh#L288

once this is merged. 

This would prevent the problematic buildup of many log files on the FNALbuild account by automatically cleaning up logfiles uploaded via Gist older than 30 days.