### PR TITLE
Allow PR authors to execute CI actions

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -244,6 +244,10 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
         return
 
     authorised_users, authed_teams = get_authorised_users(mu2eorg, repo, branch=pr.base.ref)
+    
+    # allow the PR author to execute CI actions:
+    if not issue.user.login in authorised_users:
+        authorised_users += [issue.user.login]
 
     print ("Authorised Users: ", authorised_users)
     


### PR DESCRIPTION
Allow PR authors to execute CI actions (as long as they are in the Mu2e github organisation)