### PR TITLE
remove default test from test list

### DIFF
--- a/Mu2eCI/test_suites.py
+++ b/Mu2eCI/test_suites.py
@@ -157,5 +157,4 @@ TESTS = [
     [REGEX_BUILDTEST_MU2E_PR, build_test_configuration],
     [REGEX_LINTTEST_MU2E_PR, lambda matchre: (["code checks"], "current", {})],
     [REGEX_VALIDATIONTEST_MU2E_PR, lambda matchre: (["validation"], "current", {})],
-    [REGEX_DEFTEST_MU2E_PR, lambda matchre: (DEFAULT_TESTS, "current", {})],
 ]


### PR DESCRIPTION
so garbled test commands don't accidentally trigger actual tests. Should not affect the tests that automatically run upon making a pull request