### PR TITLE
reduce Github test-runner version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]


### PR DESCRIPTION
ubuntu-latest does not support Python 3.6, which we need. This is causing tests to fail.