### PR TITLE
use fullmatch so it won't skip typos

### DIFF
--- a/Mu2eCI/common.py
+++ b/Mu2eCI/common.py
@@ -90,7 +90,7 @@ def check_test_cmd_mu2e(full_comment, repository):
 
     for regex, handler in test_suites.TESTS:
         # returns the first match in the comment
-        match = regex.search(full_comment)
+        match = regex.fullmatch(full_comment)
         if match is None:
             log.debug("NOT MATCHED - %s", str(regex.pattern))
             continue


### PR DESCRIPTION
We found that if the there is a typo in the "with" clause, then it would not match and the with clause would be ignored.  This happened with markdown and with adding a accidental "/" in the PR name.  This forces the whole command to match the expected pattern.